### PR TITLE
Search query is passed without the last character to the suggestions request

### DIFF
--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -42,13 +42,17 @@ function Search(props: SearchProps) {
   const [isStockSymbolSet, setIsStockSymbolSet] = React.useState(false);
 
   function handleChange(event: React.ChangeEvent<HTMLInputElement>) {
+    const value = event.target.value;
     if (typingTimeout) {
       clearTimeout(typingTimeout);
     }
 
-    setQuery(event.target.value);
+    if (query.length > 1) {
+      setTypingTimeout(setTimeout(() => fetchSuggestions(value), 1250));
+    }
+
+    setQuery(value);
     setIsStockSymbolSet(false);
-    setTypingTimeout(setTimeout(() => fetchSuggestions(), 500));
   }
 
   async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
@@ -57,20 +61,18 @@ function Search(props: SearchProps) {
     closeModal();
   }
 
-  async function fetchSuggestions() {
+  async function fetchSuggestions(query: string) {
     try {
-      if (query !== "") {
-        setIsLoading(true);
+      setIsLoading(true);
 
-        const apiKey = process.env.REACT_APP_ALPHA_VANTAGE_API_KEY;
-        let response = await fetch(
-          `https://www.alphavantage.co/query?function=SYMBOL_SEARCH&keywords=${query.toLowerCase()}&apikey=${apiKey}`
-        );
-        let responseData = await response.json();
+      const apiKey = process.env.REACT_APP_ALPHA_VANTAGE_API_KEY;
+      let response = await fetch(
+        `https://www.alphavantage.co/query?function=SYMBOL_SEARCH&keywords=${query.toLowerCase()}&apikey=${apiKey}`
+      );
+      let responseData = await response.json();
 
-        setSuggestions(normalizeSuggestions(responseData));
-        setIsLoading(false);
-      }
+      setSuggestions(normalizeSuggestions(responseData));
+      setIsLoading(false);
     } catch (err) {
       console.error(err);
     }

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -1,9 +1,9 @@
 import * as React from "react";
 import { Input, Stack, theme, chakra, Button, FormControl, FormHelperText } from "@chakra-ui/react";
 
+import SuggestionsList from "./SuggestionsList";
 import { getSuggestions } from "../services/getSuggestions";
 import { normalizeSuggestions } from "../utils/suggestions";
-import SuggestionsList from "./SuggestionsList";
 
 interface SearchProps {
   query: string;

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -12,7 +12,8 @@ import {
   VStack,
 } from "@chakra-ui/react";
 
-import { getSuggestions, Suggestion, SuggestionKeys, Suggestions } from "../services/getSuggestions";
+import { getSuggestions } from "../services/getSuggestions";
+import { normalizeSuggestions } from "../utils/suggestions";
 
 type SearchProps = {
   query: string;
@@ -58,15 +59,6 @@ function Search(props: SearchProps) {
 
     setSuggestions(normalizeSuggestions(suggestions));
     setIsLoading(false);
-  }
-
-  function normalizeSuggestions(suggestions: Suggestions) {
-    return suggestions.bestMatches.map(keepOnlyCompanyAndSymbolName);
-
-    /* ************************************ */
-    function keepOnlyCompanyAndSymbolName(suggestion: Suggestion) {
-      return `${suggestion[SuggestionKeys.SYMBOL]} - ${suggestion[SuggestionKeys.NAME]}`;
-    }
   }
 
   function renderSuggestions() {

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -12,18 +12,7 @@ import {
   VStack,
 } from "@chakra-ui/react";
 
-enum SuggestionKeys {
-  SYMBOL = "1. symbol",
-  NAME = "2. name",
-}
-
-type Suggestion = {
-  [key in SuggestionKeys]: string;
-};
-
-type Suggestions = {
-  bestMatches: Suggestion[];
-};
+import { getSuggestions, Suggestion, SuggestionKeys, Suggestions } from "../services/getSuggestions";
 
 type SearchProps = {
   query: string;
@@ -42,7 +31,8 @@ function Search(props: SearchProps) {
   const [isStockSymbolSet, setIsStockSymbolSet] = React.useState(false);
 
   function handleChange(event: React.ChangeEvent<HTMLInputElement>) {
-    const value = event.target.value;
+    const { value } = event.target;
+
     if (typingTimeout) {
       clearTimeout(typingTimeout);
     }
@@ -61,21 +51,13 @@ function Search(props: SearchProps) {
     closeModal();
   }
 
-  async function fetchSuggestions(query: string) {
-    try {
-      setIsLoading(true);
+  async function fetchSuggestions(searchQuery: string) {
+    setIsLoading(true);
 
-      const apiKey = process.env.REACT_APP_ALPHA_VANTAGE_API_KEY;
-      let response = await fetch(
-        `https://www.alphavantage.co/query?function=SYMBOL_SEARCH&keywords=${query.toLowerCase()}&apikey=${apiKey}`
-      );
-      let responseData = await response.json();
+    const suggestions = await getSuggestions(searchQuery);
 
-      setSuggestions(normalizeSuggestions(responseData));
-      setIsLoading(false);
-    } catch (err) {
-      console.error(err);
-    }
+    setSuggestions(normalizeSuggestions(suggestions));
+    setIsLoading(false);
   }
 
   function normalizeSuggestions(suggestions: Suggestions) {

--- a/src/components/Suggestion.tsx
+++ b/src/components/Suggestion.tsx
@@ -1,0 +1,27 @@
+import * as React from "react";
+import { Box, theme } from "@chakra-ui/react";
+
+interface IProps {
+  suggestion: string;
+  setQuery: (value: string) => void;
+  setIsStockSymbolSet: (value: boolean) => void;
+}
+
+function Suggestion({ suggestion, setIsStockSymbolSet, setQuery }: IProps) {
+  return (
+    <Box
+      as="p"
+      cursor="pointer"
+      borderBottom="1px solid transparent"
+      onClick={() => {
+        setIsStockSymbolSet(true);
+        setQuery(suggestion.split(" - ")[0]);
+      }}
+      _hover={{ borderBottomColor: theme.colors.gray[100] }}
+    >
+      {suggestion}
+    </Box>
+  );
+}
+
+export default Suggestion;

--- a/src/components/SuggestionsList.tsx
+++ b/src/components/SuggestionsList.tsx
@@ -1,0 +1,31 @@
+import * as React from "react";
+import { Box, VStack, ScaleFade } from "@chakra-ui/react";
+
+import Suggestion from "./Suggestion";
+
+interface IProps {
+  suggestions: string[];
+  setQuery: (value: string) => void;
+  setIsStockSymbolSet: (value: boolean) => void;
+}
+
+function SuggestionsList({ suggestions, setIsStockSymbolSet, setQuery }: IProps) {
+  return (
+    <VStack alignItems="start" maxHeight="10em" overflowY="auto">
+      <Box w="100%">
+        <ScaleFade initialScale={0.9} in={suggestions.length > 0}>
+          {suggestions?.map(suggestion => (
+            <Suggestion
+              key={suggestion}
+              setQuery={setQuery}
+              suggestion={suggestion}
+              setIsStockSymbolSet={setIsStockSymbolSet}
+            />
+          ))}
+        </ScaleFade>
+      </Box>
+    </VStack>
+  );
+}
+
+export default SuggestionsList;

--- a/src/services/getSuggestions.ts
+++ b/src/services/getSuggestions.ts
@@ -1,0 +1,25 @@
+export enum SuggestionKeys {
+  SYMBOL = "1. symbol",
+  NAME = "2. name",
+}
+
+export type Suggestion = {
+  [key in SuggestionKeys]: string;
+};
+
+export interface Suggestions {
+  bestMatches: Suggestion[];
+}
+
+export async function getSuggestions(query: string): Promise<Suggestions> {
+  try {
+    const apiKey = process.env.REACT_APP_ALPHA_VANTAGE_API_KEY;
+    let response = await fetch(
+      `https://www.alphavantage.co/query?function=SYMBOL_SEARCH&keywords=${query.toLowerCase()}&apikey=${apiKey}`
+    );
+
+    return await response.json();
+  } catch (err) {
+    throw new Error(err);
+  }
+}

--- a/src/utils/suggestions.ts
+++ b/src/utils/suggestions.ts
@@ -1,0 +1,9 @@
+import { Suggestion, SuggestionKeys, Suggestions } from "../services/getSuggestions";
+
+export function normalizeSuggestions(suggestions: Suggestions) {
+  return suggestions.bestMatches.map(keepOnlyCompanyAndSymbolName);
+}
+
+function keepOnlyCompanyAndSymbolName(suggestion: Suggestion) {
+  return `${suggestion[SuggestionKeys.SYMBOL]} - ${suggestion[SuggestionKeys.NAME]}`;
+}


### PR DESCRIPTION
The `<Search/>` component has the autocomplete feature such that when the user stops typing, after a timeout, a request for relevant suggestions is issued. Somehow, the last character of the search query was not part of the URL of the request.

## What changed
* fixed the bug by passing the `event.target.value` to the function responsible for fetching suggestions (instead of the `query` piece of state)
* extrated the `getSuggestions` service
* extracted the `normalizeSuggestions` utility function
* dropped the **render functions** in favor of two new components: `<Suggestions/>` & <SuggestionsList/>`
* formatting

Closes #1